### PR TITLE
Feature/use a config file

### DIFF
--- a/example.ydns.eu
+++ b/example.ydns.eu
@@ -1,0 +1,3 @@
+YDNS_USER="user@host.xx"
+YDNS_PASSWD="secret"
+YDNS_HOST="example.ydns.eu"

--- a/updater.sh
+++ b/updater.sh
@@ -48,7 +48,7 @@ fi
 ret=$(curl --basic \
 	-u "$YDNS_USER:$YDNS_PASSWD" \
 	--silent \
-	https://ydns.eu/api/v1/update/?host=$YDNS_HOST)
+	https://ydns.eu/api/v1/update/?host="$YDNS_HOST")
 
 if [ "$ret" != "ok" ]; then
 	echo "Update failed: $ret"

--- a/updater.sh
+++ b/updater.sh
@@ -16,14 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+if [ -z "${1}" ] && [ ! -r /usr/local/etc/ydns-config ] ; then
+    echo "Usage: $0: Supply the config file as /usr/local/etc/ydns-config or as the only arguement"
+    echo "Bailing."
+    exit 20
+fi
 
-##
-# Define your yDNS account details and host you'd like to update.
-##
+if [ ! -r "${1}" ] ; then
+    echo "Unable to read ${1}"
+    exit 25
+fi
 
-YDNS_USER="user@host.xx"
-YDNS_PASSWD="secret"
-YDNS_HOST="myhost.ydns.eu"
+if [ ! -z "${1}" ] ; then
+    CONFIGFILE="${1}"
+else
+    CONFIGFILE=/usr/local/etc/ydns-config
+fi
+
+. "${CONFIGFILE}"
 
 ##
 # Don't change anything below.

--- a/updater.sh
+++ b/updater.sh
@@ -35,10 +35,10 @@ fi
 
 # if this fails with error 60 your certificate store does not contain the certificate,
 # either add it or use -k (disable certificate check
-ret=`curl --basic \
+ret=$(curl --basic \
 	-u "$YDNS_USER:$YDNS_PASSWD" \
 	--silent \
-	https://ydns.eu/api/v1/update/?host=$YDNS_HOST`
+	https://ydns.eu/api/v1/update/?host=$YDNS_HOST)
 
 if [ "$ret" != "ok" ]; then
 	echo "Update failed: $ret"


### PR DESCRIPTION
This PR does two things:
  1. Stylistic fixes per [Shellcheck](http://www.shellcheck.net/)
  1. Separates the config from the code:
      - either an expected file (/usr/local/etc/ydns-config)
      - or a specified file ($1)

Not sure if you want this in upstream or not…