### PR TITLE
Persist last ip in a unique file per host

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -24,7 +24,7 @@
 YDNS_USER="user@host.xx"
 YDNS_PASSWD="secret"
 YDNS_HOST="myhost.ydns.eu"
-YDNS_LASTIP_FILE="/tmp/ydns_last_ip"
+YDNS_LASTIP_FILE="/tmp/ydns_last_ip_$YDNS_HOST"
 
 ##
 # Don't change anything below.
@@ -96,6 +96,7 @@ while getopts "hH:i:p:u:vV" opt; do
 
 		H)
 			YDNS_HOST=$OPTARG
+			YDNS_LASTIP_FILE="/tmp/ydns_last_ip_$YDNS_HOST"
 			;;
 
 		i)


### PR DESCRIPTION
This solves an issue where a single host have multiple DNS entries but only the entry in the first call is updated. Further calls for other hosts would result in a 'IP Unchanged' message.


